### PR TITLE
Bug fix and typo

### DIFF
--- a/R/tramicp.R
+++ b/R/tramicp.R
@@ -155,7 +155,7 @@ invariant_sets <- function(object, with_pvalues = FALSE) {
                    controls = controls, mandatory = mandatory, ... = ...)
 
       if (set == 1 && controls$stop_if_empty_set_invariant &&
-          ret[[1]]$test$p.value > controls$alpha) {
+          .get_pvalue(ret[[1]]$test) > controls$alpha) {
       if (verbose && interactive())
         message("\nEmpty set is not rejected. Stopping.")
         tests <- ret

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ with an alias, as shown in the table below.
 | `ColrICP()`         | `tram::Colr()`             |
 | `cotramICP()`       | `cotram::cotram()`         |
 | `CoxphICP()`        | `tram::Coxph()`            |
-| `coxphICP()`        | `survival::Coxph()`        |
+| `coxphICP()`        | `survival::coxph()`        |
 | `glmICP()`          | `stats::glm()`             |
 | `LehmannICP()`      | `tram::Lehmann()`          |
 | `LmICP()`           | `tram::Lm()`               |


### PR DESCRIPTION
Under `options(stop_if_empty_set_invariant = TRUE)`  and `type = "wald"`, the p-value for checking whether the empty set is rejected was not retrieved correctly. `.get_pvalue()` does this now. Also minor typo in the `README.md` was fixed.